### PR TITLE
Add Pagination Support for Flights Endpoint

### DIFF
--- a/src/controllers/FlightController.ts
+++ b/src/controllers/FlightController.ts
@@ -3,6 +3,7 @@ import { Request, Response } from "express";
 import { ResponseDTO } from "../dtos/response/ResponseDTO";
 
 import { FlightService } from "../services/FlightService";
+import { PaginationParamsDTO } from "../dtos/pagination/PaginationParamsDTO";
 
 export class FlightController {
     private service: FlightService;
@@ -13,9 +14,14 @@ export class FlightController {
 
     public async getAllFlights(req: Request, res: Response): Promise<void> {
         try {
-            const flights = await this.service.findAll();
+            const paginationParamsDto = new PaginationParamsDTO(
+                parseInt(req.query.page as string, 10) || 1,
+                parseInt(req.query.limit as string, 10) || 10
+            );
 
-            res.status(200).json(ResponseDTO.success(flights, 'Flights fetched successfully'));
+            const flights = await this.service.findAll(paginationParamsDto);
+
+            res.status(200).json(ResponseDTO.success(flights, 'Flights fetched successfully', paginationParamsDto));
         } catch (error) {
             res.status(500).json(ResponseDTO.error(500, 'Failed to fetch flights'));
         }

--- a/src/dtos/pagination/PaginationParamsDTO.ts
+++ b/src/dtos/pagination/PaginationParamsDTO.ts
@@ -1,0 +1,9 @@
+export class PaginationParamsDTO {
+    page: number;
+    limit: number;
+    
+    constructor(page: number = 1, limit: number = 10) {
+        this.page = page;
+        this.limit = limit;
+    }
+}

--- a/src/dtos/response/ResponseDTO.ts
+++ b/src/dtos/response/ResponseDTO.ts
@@ -1,16 +1,24 @@
+import { PaginationParamsDTO } from "../pagination/PaginationParamsDTO";
+
 export class ResponseDTO<T> {
     status: number;
     message: string;
+    page?: number;
     data?: T;
 
-    constructor(status: number, message: string, data?: T) {
+    constructor(status: number, message: string, data?: T, page?: number) {
         this.status = status;
         this.message = message;
         this.data = data;
+        if(page) {
+            this.page = page;
+        }
     }
 
-    static success<T>(data: T, message: string = 'Operation successful'): ResponseDTO<T> {
-        return new ResponseDTO<T>(200, message, data);
+    static success<T>(data: T, message: string = 'Operation successful', paginationParamsDto?: PaginationParamsDTO): ResponseDTO<T> {
+        const page = paginationParamsDto ? paginationParamsDto.page : undefined;
+
+        return new ResponseDTO<T>(200, message, data, page);
     }
 
     static created<T>(data: T, message: string = 'Resource created successfully'): ResponseDTO<T> {

--- a/src/repositories/FlightRepository.ts
+++ b/src/repositories/FlightRepository.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 
 import { Flight } from '../entities/Flight';
 import { PrismaClientSingleton } from "../config/db/PrismaClientSingleton";
+import { PaginationParamsDTO } from 'src/dtos/pagination/PaginationParamsDTO';
 
 export class FlightRepository {
     private model: PrismaClient;
@@ -10,8 +11,14 @@ export class FlightRepository {
         this.model = PrismaClientSingleton.getInstance();
     }
 
-    public async findAll(): Promise<Flight[]> {
-        const flightData = await this.model.flight.findMany();
+    public async findAll(paginationParamsDto: PaginationParamsDTO): Promise<Flight[]> {
+        const { page, limit } = paginationParamsDto;
+        const skip = (page - 1) * limit;
+
+        const flightData = await this.model.flight.findMany({
+            skip: skip,
+            take: limit,
+        });
 
         return flightData.map(flight =>
             new Flight(

--- a/src/services/FlightService.ts
+++ b/src/services/FlightService.ts
@@ -1,4 +1,5 @@
 import { FlightDTO } from "../dtos/flight/FlightDTO";
+import { PaginationParamsDTO } from "src/dtos/pagination/PaginationParamsDTO";
 
 import { FlightRepository } from "../repositories/FlightRepository";
 
@@ -9,8 +10,8 @@ export class FlightService {
         this.repository = new FlightRepository();
     }
 
-    public async findAll(): Promise<FlightDTO[]> {
-        const entities = await this.repository.findAll();
+    public async findAll(paginationParamsDto: PaginationParamsDTO): Promise<FlightDTO[]> {
+        const entities = await this.repository.findAll(paginationParamsDto);
 
         return entities.map(entity => (
             entity.toDto()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,12 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,  // This enables JSON imports
     "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@utils/*": ["src/utils/*"],
+      "@services/*": ["src/services/*"],
+      "@models/*": ["src/models/*"]
+    },
   },
   "include": ["src/**/*", "*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
This PR implements pagination for the flights listing endpoint to improve performance and usability with large datasets.

Key changes:
- Added new `PaginationParamsDTO` to handle pagination parameters
- Modified `FlightController` to accept `page` and `limit` query params
- Updated `FlightRepository` to support paginated queries
- Enhanced `ResponseDTO` to optionally include pagination metadata
- Added path aliases configuration in `tsconfig.json`

The endpoint now supports:
```
GET /flights?page=1&limit=10
```

Default values:
- page: 1
- limit: 10

This change maintains backward compatibility while providing better control over large result sets.